### PR TITLE
docs: explain why @MappedSuperclass breaks the business rule

### DIFF
--- a/src/main/java/co/edu/udistrital/mdp/pets/entities/UserEntity.java
+++ b/src/main/java/co/edu/udistrital/mdp/pets/entities/UserEntity.java
@@ -12,6 +12,13 @@ import java.util.List;
  // Cuando compare dos objetos, tambien revisa los campos que hereda del padre
 @EqualsAndHashCode(callSuper = true)
 
+//Se opto por la estrategia @Inheritance(strategy = JOINED) sobre @MappedSuperclass 
+//para permitir asociaciones polimorficas. Dado que el sistema de notificaciones debe interactuar 
+//con cualquier tipo de usuario de forma generica (Patrón Observer), 
+//necesitamos que UserEntity sea una entidad real en el modelo de persistencia. 
+//Usar @MappedSuperclass nos obligaría a duplicar la lógica de notificaciones en cada clase hija, 
+//aumentando la deuda técnica y el acoplamiento.
+
 // Estrategia para tablas unidas
 @Inheritance(strategy = InheritanceType.JOINED) 
 public abstract class UserEntity extends BaseEntity {
@@ -23,7 +30,7 @@ public abstract class UserEntity extends BaseEntity {
 	// Password es necesario para que el login() de los requerimientos funcione
     private String password;
 
-	
+
 	// Relation 1:N with Notification
 	@PodamExclude
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)


### PR DESCRIPTION
El monitor sugiere usar @MappedSuperclass para que la base de datos sea más optima, escribio que las clases abstractas no deberían ser entidades y por lo tanto no tengan relaciones.

@ MappedSuperclass:

Lo que hace: Permite que los hijos hereden campos (nombre, email, etc.), pero la clase padre no es una entidad en la base de datos. No existe una tabla User.

El problema para el diseño que tenemos planeado: No permite asociaciones OneToMany o ManyToOne. Si usamos esto que nos recomendo el monitor perdemos la capacidad de que una Notification apunte a un User genérico. Tendriamos que crear una NotificationForVet y una NotificationForAdopter. Mala idea para la arqui que tenemos.

@ Entity con @ Inheritance(strategy = InheritanceType.JOINED):

Lo que hace: Crea una tabla real para User y tabla s separadas para los hijos.

La ventaja: Permite el Polimorfismo. Puedes tener una sola tabla de Notifications donde la llave foránea apunta al ID del User, sin importar si es veterinario o adoptante.

El monitor nos recomendo lo primero porque genera más JOINs en SQL (segun la IA) y es un poco más pesado para la base de datos. Peroo nosotros no buscamos solamente optimizar la bd, el objetivo es aplicar patrones para tener el codigo limpiecito, mantenible y que aparte cumpla el principio DRY. Se que estamos pagando un pequeño costo de milisegundos en los JOINs a cambio de tener un sistema mucho más fácil de mantener, escalar y testear. No se que opinen de este trade, si quieren podemos seguir la recomendacion del monitor pero el patron observer ya no es demasiado factible, estariamos desperdiciandolo y escribiendo mas codigo para Adopter y Veterinarian.